### PR TITLE
Added pulseLength option for RCSwitch

### DIFF
--- a/lib/ST_Anything_RCSwitch/EX_RCSwitch.cpp
+++ b/lib/ST_Anything_RCSwitch/EX_RCSwitch.cpp
@@ -136,16 +136,17 @@ EX_RCSwitch::EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, u
 }
 
 // new constructor that supports bit strings (with the new RCSwitch library: https://github.com/perivar/rc-switch)
-EX_RCSwitch::EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, const char *onBitString, const char *offBitString, byte protocol, byte repeatTransmits, bool startingState) : Executor(name),
+EX_RCSwitch::EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, const char *onBitString, const char *offBitString, byte protocol, byte repeatTransmits, bool startingState, unsigned int pulseLength) : Executor(name),
 																																															 m_myRCSwitch(RCSwitch()),
 																																															 m_onBitString(onBitString),
 																																															 m_offBitString(offBitString),
 																																															 m_nProtocol(protocol),
 																																															 m_nRepeatTransmit(repeatTransmits),
-																																															 m_bCurrentState(startingState)
+																																															 m_bCurrentState(startingState),
+																																															 m_nPulseLength(pulseLength)
 {
 	setPin(transmitterPin);
-	m_myRCSwitch.setProtocol(protocol);				 // set protocol (default is 1, will work for most outlets)
+	m_myRCSwitch.setProtocol(protocol, pulseLength);				 // set protocol (default is 1, will work for most outlets)
 	m_myRCSwitch.setRepeatTransmit(repeatTransmits); // set number of transmission repetitions.
 }
 

--- a/lib/ST_Anything_RCSwitch/EX_RCSwitch.h
+++ b/lib/ST_Anything_RCSwitch/EX_RCSwitch.h
@@ -65,14 +65,17 @@ class EX_RCSwitch : public Executor
 	unsigned int m_onLength;	//RCSwitch On Length (if not using bit string)
 	unsigned long m_offCode;	//RCSwitch Off Code (if not using bit string)
 	unsigned int m_offLength;   //RCSwitch Off Length (if not using bit string)
+	unsigned int m_nPulseLength;   //RCSwitch Pulse Length 
 
 	void writeStateToPin(); //function to update the Arduino digital output pin via RCSwitch switchOn and switchOff commands
 
   public:
 	//constructor - called in your sketch's global variable declaration section
-	EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, unsigned long onCode, unsigned int onLength, unsigned long offCode, unsigned int offLength, unsigned int pulseLength, byte protocol = 1, byte repeatTransmits = 15, bool startingState = LOW);
+	EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, unsigned long onCode, unsigned int onLength, unsigned long offCode, unsigned int offLength, unsigned int pulseLength, byte protocol = 1, byte repeatTransmits = 4, bool startingState = LOW);
 	// new constructor that supports bit strings (with the new RCSwitch library: https://github.com/perivar/rc-switch)
-	EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, const char *onBitString, const char *offBitString, byte protocol = 1, byte repeatTransmits = 15, bool startingState = LOW);
+	//EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, const char *onBitString, const char *offBitString, byte protocol = 1, byte repeatTransmits = 4, bool startingState = LOW);
+  // modified new constructor that allows specification of pulseLength
+  EX_RCSwitch(const __FlashStringHelper *name, byte transmitterPin, const char *onBitString, const char *offBitString, byte protocol = 1, byte repeatTransmits = 4, bool startingState = LOW, unsigned int pulseLength = 189);
 
 	//destructor
 	virtual ~EX_RCSwitch();

--- a/src/main.ino
+++ b/src/main.ino
@@ -174,8 +174,8 @@ void setup()
   static st::EX_Switch executor2(F("switch1"), PIN_SWITCH_1, LOW, true); //Inverted logic for "Active Low" Relay Board
 
   // Add support for RF 433 Switches:
-  static st::EX_RCSwitch executor3(F("switch2"), PIN_RCSWITCH, "0000011010100110100101100110010110101010100110101010", "0000011010100110100101100110010110101010100101010101", 9, 4, LOW);
-  static st::EX_RCSwitch executor4(F("switch3"), PIN_RCSWITCH, "1001100101101010100101101010011001011001100110100110010110101010", "0", 8, 10, LOW);
+  static st::EX_RCSwitch executor3(F("switch2"), PIN_RCSWITCH, "000000010011010100000011", "000000010011010100001100", 1, 4, LOW, 189);
+  //static st::EX_RCSwitch executor4(F("switch3"), PIN_RCSWITCH, 79107, 24, 79116, 24, 189, 1, 4, LOW);
 
   //*****************************************************************************
   //  Configure debug print output from each main class
@@ -223,7 +223,7 @@ void setup()
   st::Everything::addExecutor(&executor1);
   st::Everything::addExecutor(&executor2);
   st::Everything::addExecutor(&executor3);
-  st::Everything::addExecutor(&executor4);
+  //st::Everything::addExecutor(&executor4);
 
   //*****************************************************************************
   //Initialize each of the devices which were added to the Everything Class


### PR DESCRIPTION
This way requires a pulseLength (or at least default) - alternative could be to set the pulse length based on value using 

`m_myRCSwitch.setPulseLength(pulseLength);`	